### PR TITLE
fix: remove unused "label" in Update utils.py

### DIFF
--- a/src/opendeepsearch/context_scraping/utils.py
+++ b/src/opendeepsearch/context_scraping/utils.py
@@ -88,7 +88,6 @@ def replace_newlines(text: str) -> str:
     return re.sub("\n+", " ", text)
 
 score_dict = {
-    '__label__': 0, 
     '__label__Low': 0, 
     '__label__Mid': 1,
     '__label__High': 2


### PR DESCRIPTION
This pull request removes the __label__ key from the score_dict used in the predict_educational_value function. The key was unnecessary and never used in practice, as FastText predictions always return labels with specific suffixes such as __label__Low, __label__Mid, or __label__High.

Changes:
Removed the __label__ entry from score_dict.

Ensured that only valid FastText label keys are included (__label__Low, __label__Mid, __label__High).

Rationale:
FastText uses the __label__ prefix for classification, but the base __label__ (without a class name) is not a valid or returned label.

Keeping it in the dictionary introduces unnecessary noise and may confuse future maintainers.

This change is backward-compatible and improves code clarity. No functional behavior is altered, as the removed key was never referenced.