### PR TITLE
Emtpy HTML content not always detected in _process_html_content

### DIFF
--- a/src/opendeepsearch/context_building/process_sources_pro.py
+++ b/src/opendeepsearch/context_building/process_sources_pro.py
@@ -71,7 +71,7 @@ class SourceProcessor:
         return [x['no_extraction'].content for x in raw_contents.values()]
 
     def _process_html_content(self, html: str, query: str) -> str:
-        if not html:
+        if not html.strip():
             return ""
         try:
             # Split the HTML content into chunks

--- a/src/opendeepsearch/context_building/process_sources_pro.py
+++ b/src/opendeepsearch/context_building/process_sources_pro.py
@@ -71,7 +71,7 @@ class SourceProcessor:
         return [x['no_extraction'].content for x in raw_contents.values()]
 
     def _process_html_content(self, html: str, query: str) -> str:
-        if not html.strip():
+        if not html or not html.strip():
             return ""
         try:
             # Split the HTML content into chunks


### PR DESCRIPTION
I have encountered some scenarios where attempts to check for empty `html` content in the `_process_html_content` function in src/opendeepsearch/context_building/process_sources_pro.py are failing. If the `html` content is not an empty string but consists solely of white space, the `html` content will continue to be processed. This causes a bug downstream where embeddings for an empty documents list are requested and reranking fails due to an invalid matrix multiplication attempt between the query embeddings and document embeddings.